### PR TITLE
bugfix: first claim has start_time 0

### DIFF
--- a/contracts/boidtoken/boidtoken.cpp
+++ b/contracts/boidtoken/boidtoken.cpp
@@ -1578,6 +1578,10 @@ void boidtoken::get_power_bonus(
     (float)(boidpower/c_itr->power_difficulty),
     c_itr->power_bonus_max_rate
   );
+
+  if (start_time.count() == 0) {
+    start_time = claim_time;
+  }
   
   *power_payout =
     asset{


### PR DESCRIPTION
this fixes a problem that the first claim has start_time zero and the user gets rewards worth of 50 years